### PR TITLE
Restore selinux contects

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,13 @@
     - ansible_virtualization_type != "container"
   register: selinux_manage_selinux
 
+- name: restore selinux contexts
+  shell: |
+    restorecon="$( find /sbin /usr/sbin -iname restorecon )"
+    $restorecon -R /usr /etc /var
+  when:
+    - selinux_manage_selinux.changed
+
 - name: reboot for selinux
   include_role:
     name: robertdebock.reboot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: restore selinux contexts
   shell: |
     restorecon="$( find /sbin /usr/sbin -iname restorecon )"
-    $restorecon -R /usr /etc /var /dev /sys /bin /sbin
+    $restorecon -R /usr /etc /var /dev /bin /sbin
   when:
     - selinux_manage_selinux.changed
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: restore selinux contexts
   shell: |
     restorecon="$( find /sbin /usr/sbin -iname restorecon )"
-    $restorecon -R /usr /etc /var
+    $restorecon -R /usr /etc /var /dev /sys
   when:
     - selinux_manage_selinux.changed
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: restore selinux contexts
   shell: |
     restorecon="$( find /sbin /usr/sbin -iname restorecon )"
-    $restorecon -R /usr /etc /var /dev /sys
+    $restorecon -R /usr /etc /var /dev /sys /bin /sbin
   when:
     - selinux_manage_selinux.changed
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -21,6 +21,7 @@ _selinux_requirements:
     - python3-selinux
     - python3-semanage
     - selinux-policy-default
+    - policycoreutils
   Suse:
     - libselinux1
     - python-selinux


### PR DESCRIPTION
---
name: Pull request
about: Restore selinux contects

---

**Description**
Add a task to run ```restorecon -R /usr /etc /var /dev /bin /sbin``` when selinux status changes.

I encountered an edge case where the target didn't have correct selinux file contexts on /usr/sbin/sshd . Then when I enabled selinux to enforcing, I was unable establish a secure shell connection.  selinux was blocking /usr/sbin/sshd.

Add policycoreutils to the list of required packages for Debian.  That package has ```/sbin/restorecon```.  Redhat(centos) places in restorecon in /usr/sbin.

The intent of the task to restore selinux file contexts to avoid issues when selinux is switched to enforcing.

**Testing**
Successfully ran it against a KVM Guest VM running Centos 7.
