### PR TITLE
Solves #4

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
     state: present
 
 - name: manage selinux
-  posix.selinux:
+  ansible.posix.selinux:
     state: "{{ selinux_state }}"
     policy: "{{ selinux_policy }}"
   notify:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
     state: present
 
 - name: manage selinux
-  selinux:
+  posix.selinux:
     state: "{{ selinux_state }}"
     policy: "{{ selinux_policy }}"
   notify:


### PR DESCRIPTION
---
name: Solves #4 
about:
 In Ansible 2.10, the `selinux` module has been moved to the `ansible.posix` collection.
---

**Describe the change**
Specifies the new module path for the `selinux` module for Ansible 2.10.
