### PR TITLE
Replace "is bool" with working alternative

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -20,7 +20,7 @@
   assert:
     that:
       - selinux_reboot is defined
-      - selinux_reboot is boolean
+      - selinux_reboot | bool in [true, false]
     quiet: yes
 
 - name: test if selinux_booleans is set correctly


### PR DESCRIPTION
---
name: Pull request
about: Replaces `is bool` (*which seems not to work under Ansible 2.9.6*) with a working alternative - fixes issue #6 
---

**Describe the change**
According to issue #6, it looks like the conditional check `is bool` is not working.
It was replaced with a working alternative. Please check if this could improve the code.

**Testing**
I ran the tests using Molecule.
